### PR TITLE
Add Tailwind setup for web and mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,8 @@ npm install
 npm start
 ```
 
+The mobile project is configured with [NativeWind](https://www.nativewind.dev/) to
+use Tailwind classes in React Native components. Styles are generated from
+`tailwind.config.js` and Babel is configured with the `nativewind/babel` plugin.
+
 The project uses TailwindCSS, Supabase, React/Next.js and React Native with Expo. UI text is fully internationalized with `react-i18next` and comes with example translations for English, Russian, Ukrainian and French.

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel'],
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -40,14 +40,16 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "nativewind": "^4.1.23"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "tailwindcss": "^4"
   },
   "private": true
 }

--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,4 +1,6 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind config for Next.js web
- load Tailwind layers in `globals.css`
- configure NativeWind for the Expo mobile app
- document NativeWind setup in README

## Testing
- `npm run lint` in `web` *(fails: next not found)*
- `npm run lint` in `mobile` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac50621e0832c87d15053dc525bb4