### PR TITLE
Add Supabase auth and location table

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from 'react-native';
 import CroissantMap from '@/components/CroissantMap';
 import { useTranslation } from 'react-i18next';
+import AddCroissantForm from '@/components/AddCroissantForm';
 
 export default function HomeScreen() {
   const { t } = useTranslation();
@@ -10,6 +11,7 @@ export default function HomeScreen() {
         {t('map.title')}
       </Text>
       <CroissantMap />
+      <AddCroissantForm />
     </View>
   );
 }

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -13,6 +13,7 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="login" options={{ title: 'Login' }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/mobile/app/login.tsx
+++ b/mobile/app/login.tsx
@@ -1,0 +1,21 @@
+import { View, Button } from 'react-native';
+import { supabase } from '../supabaseClient';
+
+export default function LoginScreen() {
+  const signIn = async (provider: 'google' | 'github' | 'apple') => {
+    await supabase.auth.signInWithOAuth({ provider });
+  };
+
+  const signInAnon = async () => {
+    await supabase.auth.signInAnonymously();
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', gap: 8 }}>
+      <Button title="Sign in with Google" onPress={() => signIn('google')} />
+      <Button title="Sign in with GitHub" onPress={() => signIn('github')} />
+      <Button title="Sign in with Apple" onPress={() => signIn('apple')} />
+      <Button title="Continue as Guest" onPress={signInAnon} />
+    </View>
+  );
+}

--- a/mobile/components/AddCroissantForm.tsx
+++ b/mobile/components/AddCroissantForm.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import { supabase } from '../supabaseClient';
+
+export default function AddCroissantForm() {
+  const [name, setName] = useState('');
+  const [lat, setLat] = useState('');
+  const [lng, setLng] = useState('');
+
+  const handleSubmit = async () => {
+    if (!name || !lat || !lng) return;
+    await supabase.from('croissant_locations').insert({
+      name,
+      lat: parseFloat(lat),
+      lng: parseFloat(lng),
+    });
+    setName('');
+    setLat('');
+    setLng('');
+  };
+
+  return (
+    <View style={{ gap: 8 }}>
+      <TextInput placeholder="Name" value={name} onChangeText={setName} style={{ borderWidth: 1, padding: 4 }} />
+      <TextInput placeholder="Lat" value={lat} onChangeText={setLat} style={{ borderWidth: 1, padding: 4 }} />
+      <TextInput placeholder="Lng" value={lng} onChangeText={setLng} style={{ borderWidth: 1, padding: 4 }} />
+      <Button title="Add" onPress={handleSubmit} />
+    </View>
+  );
+}

--- a/mobile/components/CroissantMap.tsx
+++ b/mobile/components/CroissantMap.tsx
@@ -1,6 +1,15 @@
 import MapView, { Marker } from 'react-native-maps';
 import { StyleSheet, View, Button } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+interface Location {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+}
 
 export default function CroissantMap() {
   const { t } = useTranslation();
@@ -10,11 +19,22 @@ export default function CroissantMap() {
     latitudeDelta: 0.01,
     longitudeDelta: 0.01,
   };
+  const [locations, setLocations] = useState<Location[]>([]);
+
+  useEffect(() => {
+    const fetchLocations = async () => {
+      const { data } = await supabase.from('croissant_locations').select('*');
+      if (data) setLocations(data as Location[]);
+    };
+    fetchLocations();
+  }, []);
 
   return (
     <View style={styles.container}>
       <MapView style={styles.map} initialRegion={region}>
-        <Marker coordinate={region} title="Eiffel Croissant" description="🥐" />
+        {locations.map((loc) => (
+          <Marker key={loc.id} coordinate={{ latitude: loc.lat, longitude: loc.lng }} title={loc.name} description="🥐" />
+        ))}
       </MapView>
       <Button title={t('map.go')} onPress={() => {}} />
     </View>

--- a/mobile/supabaseClient.ts
+++ b/mobile/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL as string;
+const supabaseKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/supabase/croissant_locations.sql
+++ b/supabase/croissant_locations.sql
@@ -1,0 +1,9 @@
+-- Table for storing croissant locations
+create table if not exists public.croissant_locations (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users not null,
+  name text not null,
+  lat double precision not null,
+  lng double precision not null,
+  created_at timestamp with time zone default now()
+);

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { supabase } from '../../supabaseClient';
+
+export default function Login() {
+  const signIn = async (provider: 'google' | 'github' | 'apple') => {
+    await supabase.auth.signInWithOAuth({ provider });
+  };
+
+  const signInAnon = async () => {
+    await supabase.auth.signInAnonymously();
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-2 p-4">
+      <button className="bg-blue-500 text-white px-4 py-2 rounded" onClick={() => signIn('google')}>Sign in with Google</button>
+      <button className="bg-gray-800 text-white px-4 py-2 rounded" onClick={() => signIn('github')}>Sign in with GitHub</button>
+      <button className="bg-black text-white px-4 py-2 rounded" onClick={() => signIn('apple')}>Sign in with Apple</button>
+      <button className="bg-green-500 text-white px-4 py-2 rounded" onClick={signInAnon}>Continue as Guest</button>
+    </div>
+  );
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,6 +2,7 @@
 import CroissantMap from '../components/CroissantMap';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '../components/LanguageSwitcher';
+import AddCroissantForm from '../components/AddCroissantForm';
 
 export default function Home() {
   const { t } = useTranslation();
@@ -10,6 +11,7 @@ export default function Home() {
       <LanguageSwitcher />
       <h1 className="text-2xl font-bold">{t('map.title')}</h1>
       <CroissantMap />
+      <AddCroissantForm />
     </main>
   );
 }

--- a/web/src/components/AddCroissantForm.tsx
+++ b/web/src/components/AddCroissantForm.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+export default function AddCroissantForm() {
+  const [name, setName] = useState('');
+  const [lat, setLat] = useState('');
+  const [lng, setLng] = useState('');
+
+  const handleSubmit = async () => {
+    if (!name || !lat || !lng) return;
+    await supabase.from('croissant_locations').insert({
+      name,
+      lat: parseFloat(lat),
+      lng: parseFloat(lng),
+    });
+    setName('');
+    setLat('');
+    setLng('');
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <input className="border p-1" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
+      <input className="border p-1" placeholder="Lat" value={lat} onChange={(e) => setLat(e.target.value)} />
+      <input className="border p-1" placeholder="Lng" value={lng} onChange={(e) => setLng(e.target.value)} />
+      <button className="bg-blue-500 text-white px-2 py-1" onClick={handleSubmit}>Add</button>
+    </div>
+  );
+}

--- a/web/src/components/CroissantMap.tsx
+++ b/web/src/components/CroissantMap.tsx
@@ -1,28 +1,49 @@
 "use client";
+import { useEffect, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import { LatLngExpression, divIcon } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useTranslation } from 'react-i18next';
+import { supabase } from '../supabaseClient';
+
+interface Location {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+}
 
 const icon = divIcon({ html: '🥐', className: '', iconSize: [24, 24] });
 
 export default function CroissantMap() {
   const position: LatLngExpression = [48.8584, 2.2945];
   const { t } = useTranslation();
+  const [locations, setLocations] = useState<Location[]>([]);
+
+  useEffect(() => {
+    const fetchLocations = async () => {
+      const { data } = await supabase.from('croissant_locations').select('*');
+      if (data) setLocations(data as Location[]);
+    };
+    fetchLocations();
+  }, []);
+
   return (
     <MapContainer center={position} zoom={13} style={{ height: '60vh', width: '100%' }}>
       <TileLayer
         attribution='&copy; OpenStreetMap contributors'
         url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       />
-      <Marker position={position} icon={icon}>
-        <Popup>
-          <div className="flex flex-col">
-            <strong>Eiffel Croissant</strong>
-            <button className="mt-2 bg-blue-500 text-white px-2 py-1 rounded">{t('map.go')}</button>
-          </div>
-        </Popup>
-      </Marker>
+      {locations.map((loc) => (
+        <Marker key={loc.id} position={[loc.lat, loc.lng]} icon={icon}>
+          <Popup>
+            <div className="flex flex-col">
+              <strong>{loc.name}</strong>
+              <button className="mt-2 bg-blue-500 text-white px-2 py-1 rounded">{t('map.go')}</button>
+            </div>
+          </Popup>
+        </Marker>
+      ))}
     </MapContainer>
   );
 }


### PR DESCRIPTION
## Summary
- add Supabase login pages on web and mobile
- connect maps to Supabase croissant locations
- allow submitting new locations
- add SQL for croissant_locations table

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run lint` in mobile *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac5364890832cb7820e6bc1c86666