### PR TITLE
Enable device language detection on mobile

### DIFF
--- a/mobile/i18n.ts
+++ b/mobile/i18n.ts
@@ -1,5 +1,6 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import * as Localization from 'expo-localization';
 import en from './locales/en/translation.json';
 import ru from './locales/ru/translation.json';
 import uk from './locales/uk/translation.json';
@@ -12,9 +13,18 @@ const resources = {
   fr: { translation: fr },
 };
 
+const availableLanguages = Object.keys(resources);
+const deviceLanguage =
+  Localization.getLocales?.()[0]?.languageCode ||
+  Localization.locale.split('-')[0];
+
+const lng = availableLanguages.includes(deviceLanguage)
+  ? deviceLanguage
+  : 'en';
+
 i18n.use(initReactI18next).init({
   resources,
-  lng: 'en',
+  lng,
   fallbackLng: 'en',
   interpolation: { escapeValue: false },
 });

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -29,6 +29,7 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.8",
     "expo-web-browser": "~14.1.6",
+    "expo-localization": "~14.6.0",
     "i18next": "^23.8.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
## Summary
- detect device language with expo-localization in mobile app
- add expo-localization dependency

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac5478cb8832cad58b7c97744837e